### PR TITLE
Fix: Nginx spring 경로 수정

### DIFF
--- a/nginx/conf.d/application.conf
+++ b/nginx/conf.d/application.conf
@@ -19,7 +19,8 @@ server {
 
     location ~ ^/(api/|swagger-ui/|api-docs) {
         resolver            127.0.0.11;
-        set $server_url     http://host.docker.internal:8080;
+        #set $server_url     http://host.docker.internal:8080;
+        set $server_url     http://spring:8080;
         proxy_pass          $server_url;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
http://host.docker.internal:8080에서 http://spring:8080로 변경